### PR TITLE
Add missing python-ranges dependency and remove debug print

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -66,7 +66,6 @@ def _compare_point(comparisons, point):
     for sign, value in comparisons.items():
         if isinstance(point, datetime.datetime):
             value = dateutil.parser.isoparse(value)
-        print("Compare: ", sign, point, value)
         if not _compare_sign(sign, point, value):
             return False
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openmock"
-version = "2.0.0"
+version = "2.1.0"
 description = "Python OpenSearch Mock for test purposes"
 authors = ["Marcos Cardoso",
     "Mathew Martin <matthewdeanmartin@gmail.com>"]
@@ -17,9 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "License :: OSI Approved :: MIT License",
     "Topic :: Software Development :: Libraries :: Python Modules"
@@ -35,9 +32,10 @@ include = [
 "Change Log" = "https://github.com/matthewdeanmartin/openmock/blob/main/CHANGES.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4"
+python = ">=3.9,<4"
 opensearch-py = "*"
 python-dateutil = "*"
+python-ranges = "^1.2.1"
 
 [tool.poetry.dev-dependencies]
 parameterized = "*"


### PR DESCRIPTION
1. Removed debug print
2. Added python-ranges as dep, and removed compatibility with `python <= 3.8`
3. Bumped minor version, since range-field support is a new feature.