### PR TITLE
add update() to FakeOpenSearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+/poetry.lock

--- a/tests/fake_opensearch/test_update.py
+++ b/tests/fake_opensearch/test_update.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from opensearchpy.exceptions import NotFoundError, RequestError
+
+from tests import Testopenmock, INDEX_NAME, BODY
+
+UPDATED_BODY = {"author": "schenkd", "text": "Updated Text"}
+
+
+class TestUpdate(Testopenmock):
+    def test_update_document(self):
+        new_document = self.es.index(index=INDEX_NAME, body=BODY)
+        updated_document = self.es.update(
+            index=INDEX_NAME, id=new_document.get("_id"), body={"doc": UPDATED_BODY}
+        )
+
+        self.assertEqual(
+            new_document.get("_version") + 1, updated_document.get("_version")
+        )
+        self.assertEqual(INDEX_NAME, updated_document.get("_index"))
+        self.assertEqual("updated", updated_document.get("result"))
+
+        check_document = self.es.get(index=INDEX_NAME, id=new_document.get("_id"))
+        self.assertEqual(
+            check_document.get("_source", {}).get("author"), UPDATED_BODY["author"]
+        )
+
+    def test_update_document_not_found(self):
+        with self.assertRaises(NotFoundError):
+            self.es.update(
+                index=INDEX_NAME, id="not-a-real-id", body={"doc": UPDATED_BODY}
+            )
+
+    def test_update_document_wrong_body(self):
+        with self.assertRaises(RequestError):
+            self.es.update(index=INDEX_NAME, id="not-a-real-id", body={"key": "value"})
+
+        with self.assertRaises(RequestError):
+            self.es.update(index=INDEX_NAME, id="not-a-real-id", body={})
+
+        with self.assertRaises(RequestError):
+            self.es.update(index=INDEX_NAME, id="not-a-real-id", body={"doc": {}, "script": {}})
+
+    def test_update_document_script_not_implemented(self):
+        new_document = self.es.index(index=INDEX_NAME, body=BODY)
+
+        with self.assertRaises(NotImplementedError):
+            self.es.update(index=INDEX_NAME, id=new_document.get("_id"), body={"script": {}})


### PR DESCRIPTION
Hello @matthewdeanmartin,

thank you very much for your work on openmock!
I've start using it and was wondering why my tests fails on the .update function that I'm using with OpenSearch.
Seems that no one is using it till now in combination with the openmock lib.

I've spend some time implementing the missing method to enable our Team to use your openmock lib.
The painless script is currently not supported by this implementation since we are not using it.

Since openmock is not mocking the behaviour of the _primary_term and _seq_no, I didn't add them to the update result. That's totaly fine for me. I could implement it in a seperate pull request if it's something that you'd also like to mock.

Summary
* added update() method with support for doc update
* added unittests
* handles exception raising like OpenSearch

Thanks for your review!
Best David