### PR TITLE
Added mock for opensearchpy create function

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -386,6 +386,40 @@ class FakeOpenSearch(OpenSearch):
         "version",
         "version_type",
     )
+
+    def create(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
+        if self.exists(index, id, doc_type=doc_type, params=params):
+            raise RequestError(
+                409,
+                "action_request_validation_exception",
+                "Validation Failed: 1: no documents to get;",
+            )
+
+        if index not in self.__documents_dict:
+            self.__documents_dict[index] = []
+
+        if id is None:
+            id = get_random_id()
+
+        self.__documents_dict[index].append(
+            {
+                "_type": doc_type,
+                "_id": id,
+                "_source": body,
+                "_index": index,
+                "_version": 1,
+            }
+        )
+
+        return {
+            "_type": doc_type,
+            "_id": id,
+            "created": True,
+            "_version": 1,
+            "_index": index,
+            "result": "created",
+        }
+
     def index(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
         if index not in self.__documents_dict:
             self.__documents_dict[index] = []
@@ -503,7 +537,7 @@ class FakeOpenSearch(OpenSearch):
                         }
                     }
                     if not error:
-                        item[action]["result"] = result
+                        item[action]["result" ] = result
                         if self.exists(
                             index, document_id, doc_type=doc_type, params=params
                         ):

--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -11,7 +11,7 @@ import ranges
 
 from opensearchpy import OpenSearch
 from opensearchpy.client.utils import query_params
-from opensearchpy.exceptions import NotFoundError, RequestError
+from opensearchpy.exceptions import NotFoundError, RequestError, ConflictError
 from opensearchpy.transport import Transport
 
 from openmock.behaviour.server_failure import server_failure
@@ -389,7 +389,7 @@ class FakeOpenSearch(OpenSearch):
 
     def create(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
         if self.exists(index, id, doc_type=doc_type, params=params):
-            raise RequestError(
+            raise ConflictError(
                 409,
                 "action_request_validation_exception",
                 "Validation Failed: 1: no documents to get;",

--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -595,9 +595,7 @@ class FakeOpenSearch(OpenSearch):
         result = False
         if index in self.__documents_dict:
             for document in self.__documents_dict[index]:
-                if document.get("_id") == id and (
-                    document.get("_type") == doc_type or doc_type is None
-                ):
+                if document.get("_id") == id and document.get("_type") == doc_type:
                     result = True
                     break
         return result

--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -537,7 +537,7 @@ class FakeOpenSearch(OpenSearch):
                         }
                     }
                     if not error:
-                        item[action]["result" ] = result
+                        item[action]["result"] = result
                         if self.exists(
                             index, document_id, doc_type=doc_type, params=params
                         ):

--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -386,7 +386,6 @@ class FakeOpenSearch(OpenSearch):
         "version",
         "version_type",
     )
-
     def create(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
         if self.exists(index, id, doc_type=doc_type, params=params):
             raise ConflictError(
@@ -596,7 +595,9 @@ class FakeOpenSearch(OpenSearch):
         result = False
         if index in self.__documents_dict:
             for document in self.__documents_dict[index]:
-                if document.get("_id") == id and document.get("_type") == doc_type:
+                if document.get("_id") == id and (
+                    document.get("_type") == doc_type or doc_type is None
+                ):
                     result = True
                     break
         return result

--- a/tests/fake_opensearch/test_create.py
+++ b/tests/fake_opensearch/test_create.py
@@ -45,4 +45,11 @@ class TestCreate(Testopenmock):
     def test_should_throw_error_if_doc_exists(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
         document_id = data.get("_id")
-        self.assertRaises(ConflictError, self.es.create, INDEX_NAME, UPDATED_BODY, DOC_TYPE, document_id)
+        self.assertRaises(
+            ConflictError,
+            self.es.create,
+            INDEX_NAME,
+            UPDATED_BODY,
+            DOC_TYPE,
+            document_id,
+        )

--- a/tests/fake_opensearch/test_create.py
+++ b/tests/fake_opensearch/test_create.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from tests import Testopenmock, INDEX_NAME, DOC_TYPE, BODY
+from opensearchpy.exceptions import ConflictError
+
+UPDATED_BODY = {"author": "vrcmarcos", "text": "Updated Text"}
+
+
+class TestCreate(Testopenmock):
+    def test_should_create_document(self):
+        data = self.es.create(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
+
+        self.assertEqual(DOC_TYPE, data.get("_type"))
+        self.assertTrue(data.get("created"))
+        self.assertEqual(1, data.get("_version"))
+        self.assertEqual(INDEX_NAME, data.get("_index"))
+        self.assertEqual("created", data.get("result"))
+
+    def test_should_index_document_without_doc_type(self):
+        data = self.es.index(index=INDEX_NAME, body=BODY)
+
+        self.assertEqual("_doc", data.get("_type"))
+        self.assertTrue(data.get("created"))
+        self.assertEqual(1, data.get("_version"))
+        self.assertEqual(INDEX_NAME, data.get("_index"))
+
+    def test_doc_type_can_be_list(self):
+        doc_types = ["1_idx", "2_idx", "3_idx"]
+        count_per_doc_type = 3
+
+        for doc_type in doc_types:
+            for _ in range(count_per_doc_type):
+                self.es.index(index=INDEX_NAME, doc_type=doc_type, body={})
+
+        result = self.es.search(doc_type=[doc_types[0]])
+        self.assertEqual(
+            count_per_doc_type, result.get("hits").get("total").get("value")
+        )
+
+        result = self.es.search(doc_type=doc_types[:2])
+        self.assertEqual(
+            count_per_doc_type * 2, result.get("hits").get("total").get("value")
+        )
+
+    def test_should_throw_error_if_doc_exists(self):
+        data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
+        document_id = data.get("_id")
+        self.assertRaises(ConflictError, self.es.create, INDEX_NAME, UPDATED_BODY, DOC_TYPE, document_id)

--- a/tests/fake_opensearch/test_create.py
+++ b/tests/fake_opensearch/test_create.py
@@ -16,8 +16,8 @@ class TestCreate(Testopenmock):
         self.assertEqual(INDEX_NAME, data.get("_index"))
         self.assertEqual("created", data.get("result"))
 
-    def test_should_index_document_without_doc_type(self):
-        data = self.es.index(index=INDEX_NAME, body=BODY)
+    def test_should_create_document_without_doc_type(self):
+        data = self.es.create(index=INDEX_NAME, body=BODY)
 
         self.assertEqual("_doc", data.get("_type"))
         self.assertTrue(data.get("created"))
@@ -30,7 +30,7 @@ class TestCreate(Testopenmock):
 
         for doc_type in doc_types:
             for _ in range(count_per_doc_type):
-                self.es.index(index=INDEX_NAME, doc_type=doc_type, body={})
+                self.es.create(index=INDEX_NAME, doc_type=doc_type, body={})
 
         result = self.es.search(doc_type=[doc_types[0]])
         self.assertEqual(


### PR DESCRIPTION
*Sorry if you're not accepting external contributions. I started using this library and noticed it doesn't currently have opensearchpy's create function that I need mocked. I figured I'd submit my changes and see.*

# Changes 
- Added mock for opensearchpy's [OpenSearch.create method](https://opensearch-project.github.io/opensearch-py/api-ref/clients/opensearch_client.html#opensearchpy.OpenSearch.create) 
- This method creates a new document if one does not already exist or returns a 409 response if the document already exists.
- Added 4 unit tests for new method