### PR TITLE
updated exists method to ignore doctype checks when None

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -595,7 +595,9 @@ class FakeOpenSearch(OpenSearch):
         result = False
         if index in self.__documents_dict:
             for document in self.__documents_dict[index]:
-                if document.get("_id") == id and document.get("_type") == doc_type:
+                if document.get("_id") == id and (
+                    document.get("_type") == doc_type or doc_type is None
+                ):
                     result = True
                     break
         return result

--- a/tests/fake_opensearch/test_exists.py
+++ b/tests/fake_opensearch/test_exists.py
@@ -13,3 +13,8 @@ class TestExists(Testopenmock):
         self.assertTrue(
             self.es.exists(index=INDEX_NAME, doc_type=DOC_TYPE, id=document_id)
         )
+
+    def test_should_return_exists_true_if_index_id_matches_and_doctype_none(self):
+        data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
+        document_id = data.get("_id")
+        self.assertTrue(self.es.exists(index=INDEX_NAME, id=document_id))


### PR DESCRIPTION
# Change Overview
Currently, the exists() method in FakeOpenSearch relies on getting a document type that is used alongside the index and document id when checking if a document exists. If a document type is not input, it defaults to None and will return false because it checks, for example, if the document type "_doc" == None.

The opensearchpy implementation does not need a document type input and only needs the index name and document id to check for the existence of the document. In openmock, the exists method should ignore whether the document type matches when the value is None.

## File Changes
- fake_opensearch.py
   - added a condition so that if the doc_type in exists() is None, then only the index name and document id are used to check if the document matches. This is to better align with the openearchpy implementation.
- test_exists.py
   - added 1 test for None doc_type in exists method.

