### PR TITLE
Fix incomplete nested data search in method _compare_value_for_field

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -313,11 +313,10 @@ class FakeQueryCondition:
         for k in field.split("."):
             if hasattr(doc_val, k):
                 doc_val = getattr(doc_val, k)
-                break
-            if k in doc_val:
+            elif k in doc_val:
                 doc_val = doc_val[k]
-                break
-            return False
+            else:
+                return False
 
         if not isinstance(doc_val, list):
             doc_val = [doc_val]


### PR DESCRIPTION
**Description**: loop through all (nested) data fields in method `_compare_value_for_field`. Previously, it used to look only at the top (nested) data field, therefore, possibly giving ambiguous search results.