### PR TITLE
Implement querying by keyword datatype

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -320,6 +320,9 @@ class FakeQueryCondition:
         doc_val = doc_source
         # Remove boosting
         field, *_ = field.split("*")
+        # Remove ".keyword"
+        exact_search = field.lower().endswith(".keyword")
+        field = field[:-len(".keyword")] if exact_search else field
         for k in field.split("."):
             if hasattr(doc_val, k):
                 doc_val = getattr(doc_val, k)
@@ -339,7 +342,7 @@ class FakeQueryCondition:
 
             if value == val:
                 return True
-            if isinstance(val, str) and str(value) in val:
+            if isinstance(val, str) and str(value) in val and not exact_search:
                 return True
 
         return False

--- a/tests/fake_opensearch/test_search.py
+++ b/tests/fake_opensearch/test_search.py
@@ -120,6 +120,33 @@ class TestSearch(Testopenmock):
         self.assertEqual(len(hits), 1)
         self.assertEqual(hits[0]["_source"], {"data": "test_3"})
 
+    def test_search_with_match_keyword_query(self):
+        for i in range(0, 10):
+            self.es.index(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
+
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"match": {"data.keyword": "TEST"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 0)
+        hits = response["hits"]["hits"]
+        self.assertEqual(len(hits), 0)
+
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"match": {"data.keyword": "TEST_1"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        hits = response["hits"]["hits"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["_source"], {"data": "test_1"})
+
     def test_search_with_match_query_in_int_list(self):
         for i in range(0, 10):
             self.es.index(


### PR DESCRIPTION
**Description**: implemented a check for cases when querying by `keyword` datatype, used for exact (not partial!) field value search.