### PR TITLE
Add `min_score` param & add `MINIUM_SHOULD_MATCH` implementation

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -175,6 +175,8 @@ class FakeQueryCondition:
             return self._evaluate_for_must_not_query_type(document)
         if self.type == QueryType.EXISTS:
             return self._evaluate_for_exists_query_type(document)
+        if self.type == QueryType.MINIMUM_SHOULD_MATCH:
+            return self._evaluate_for_compound_query_type(document)
         raise NotImplementedError(
             f"Fake query evaluation not implemented for query type: {self.type}"
         )

--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -873,6 +873,7 @@ class FakeOpenSearch(OpenSearch):
         "ignore_unavailable",
         "lenient",
         "lowercase_expanded_terms",
+        "min_score",
         "preference",
         "q",
         "request_cache",


### PR DESCRIPTION
For our tests we need the `min_score` param in the `count` function, and a `MINIUM_SHOULD_MATCH` implementation. Our tests work as expected with these changes.