### PR TITLE
Fix Missing Await for Async Calls and Set AsyncTransport as Default

### DIFF
--- a/openmock/fake_asyncopensearch.py
+++ b/openmock/fake_asyncopensearch.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 import opensearchpy
 from opensearchpy.client.utils import query_params
 from opensearchpy.exceptions import ConflictError, NotFoundError, RequestError
-from opensearchpy.transport import Transport
+from opensearchpy import AsyncTransport
 
 from openmock.behaviour.server_failure import server_failure
 from openmock.fake_cluster import FakeClusterClient
@@ -36,7 +36,7 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
         # self.__documents_dict = {}
         self._FakeIndicesClient__documents_dict = {}
         self.__scrolls = {}
-        self.transport = Transport(_normalize_hosts(hosts), **kwargs)
+        self.transport = AsyncTransport(_normalize_hosts(hosts), **kwargs)
 
         # This blows up if I call the real base.
         # super(FakeOpenSearch, self).__init__()
@@ -234,7 +234,7 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
                     document_id = line[action].get("_id", get_random_id())
 
                     if action == "delete":
-                        status, result, error = self._validate_action(
+                        status, result, error = await self._validate_action(
                             action, index, document_id, doc_type, params=params
                         )
                         item = {
@@ -250,7 +250,7 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
                             errors = True
                             item[action]["error"] = result
                         else:
-                            self.delete(
+                            await self.delete(
                                 index, document_id, doc_type=doc_type, params=params
                             )
                             item[action]["result"] = result
@@ -263,7 +263,7 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
                         source = line["doc"]
                     else:
                         source = line
-                    status, result, error = self._validate_action(
+                    status, result, error = await self._validate_action(
                         action, index, document_id, doc_type, params=params
                     )
                     item = {
@@ -277,14 +277,14 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
                     }
                     if not error:
                         item[action]["result"] = result
-                        if self.exists(
+                        if await self.exists(
                             index, document_id, doc_type=doc_type, params=params
                         ):
-                            doc = self.get(
+                            doc = await self.get(
                                 index, document_id, doc_type=doc_type, params=params
                             )
                             version = doc["_version"] + 1
-                            self.delete(
+                            await self.delete(
                                 index, document_id, doc_type=doc_type, params=params
                             )
 

--- a/openmock/fake_asyncopensearch.py
+++ b/openmock/fake_asyncopensearch.py
@@ -87,7 +87,7 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
         "version_type",
     )
     # def create(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
-    async def create(
+    async def create(  # pylint: disable=too-many-positional-arguments
         self,
         index: Any,
         id: Any,
@@ -142,7 +142,7 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
         "version_type",
     )
     # def index(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
-    async def index(
+    async def index(  # pylint: disable=too-many-positional-arguments
         self,
         index: Any,
         body: Any,
@@ -303,7 +303,9 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
                     items.append(item)
         return {"errors": errors, "items": items}
 
-    async def _validate_action(self, action, index, document_id, doc_type, params=None):
+    async def _validate_action(
+        self, action, index, document_id, doc_type, params=None
+    ):  # pylint: disable=too-many-positional-arguments
         if action in ["index", "update"] and self.exists(
             index, id=document_id, doc_type=doc_type, params=params
         ):
@@ -404,7 +406,9 @@ class AsyncFakeOpenSearch(opensearchpy.AsyncOpenSearch):
         "timeout",
         "wait_for_active_shards",
     )
-    async def update(self, index, id, body, params=None, headers=None):
+    async def update(
+        self, index, id, body, params=None, headers=None
+    ):  # pylint: disable=too-many-positional-arguments
         if not body:
             raise RequestError(
                 400,

--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -406,7 +406,7 @@ class FakeOpenSearch(OpenSearch):
         "version_type",
     )
     # def create(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
-    def create(
+    def create(  # pylint: disable=too-many-positional-arguments
         self,
         index: Any,
         id: Any,
@@ -461,7 +461,7 @@ class FakeOpenSearch(OpenSearch):
         "version_type",
     )
     # def index(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
-    def index(
+    def index(  # pylint: disable=too-many-positional-arguments
         self,
         index: Any,
         body: Any,
@@ -622,7 +622,9 @@ class FakeOpenSearch(OpenSearch):
                     items.append(item)
         return {"errors": errors, "items": items}
 
-    def _validate_action(self, action, index, document_id, doc_type, params=None):
+    def _validate_action(
+        self, action, index, document_id, doc_type, params=None
+    ):  # pylint: disable=too-many-positional-arguments
         if action in ["index", "update"] and self.exists(
             index, id=document_id, doc_type=doc_type, params=params
         ):
@@ -723,7 +725,9 @@ class FakeOpenSearch(OpenSearch):
         "timeout",
         "wait_for_active_shards",
     )
-    def update(self, index, id, body, params=None, headers=None):
+    def update(
+        self, index, id, body, params=None, headers=None
+    ):  # pylint: disable=too-many-positional-arguments
         if not body:
             raise RequestError(
                 400,


### PR DESCRIPTION
- Fix an issue where asynchronous calls were not being properly awaited, ensuring correct execution flow.
- Update the default transport to AsyncTransport for consistency
