### PR TITLE
Fix search on nested data that is set to null

### DIFF
--- a/openmock/fake_opensearch.py
+++ b/openmock/fake_opensearch.py
@@ -324,7 +324,7 @@ class FakeQueryCondition:
         for k in field.split("."):
             if hasattr(doc_val, k):
                 doc_val = getattr(doc_val, k)
-            elif k in doc_val:
+            elif doc_val is not None and k in doc_val:
                 doc_val = doc_val[k]
             else:
                 return False


### PR DESCRIPTION
Error occurs when doing query on looking for a nested id, but the nested object is nullable.

Doc:


`
{
     user: null,
}
`

search Query

`{"query": {"match": {"user.id": user_id}}}`

This would result in Error:

`self = <test.packages.openmock.fake_opensearch.FakeQueryCondition object at 0x106ab9a60>, doc_source = {'first_name': 'ABC', 'id': 'mem2', 'user': None}, field = 'user.id', value = 'user2'
ignore_case = True

    def _compare_value_for_field(self, doc_source, field, value, ignore_case):
        if ignore_case and isinstance(value, str):
            value = value.lower()
    
        doc_val = doc_source
        # Remove boosting
        field, *_ = field.split("*")
        # Remove ".keyword"
        exact_search = field.lower().endswith(".keyword")
        field = field[: -len(".keyword")] if exact_search else field
        for k in field.split("."):
            if hasattr(doc_val, k):
                doc_val = getattr(doc_val, k)
           elif k in doc_val:
E           TypeError: argument of type 'NoneType' is not iterable` 

Adding None check solves this issue and gives the expected result