### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4.1.7
       with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+stages:
+  - test
+
+tox:
+  stage: test
+  image: python:$PYTHON_VERSION
+  parallel:
+    matrix:
+      - PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+  script:
+    - pip install tox
+    - tox -e py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,6 @@ pylint openmock
 pytest tests
 ```
 
-On gitlab, it will run tox and check against python 3.6 thru 3.11 all versions of openmock.
+On gitlab, it will run tox and check against python 3.9 thru 3.14 for all versions of openmock.
 
 See [build.yaml](.github/workflows/build.yaml) and [tox.yaml](.github/workflows/tox.yaml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py311-opensearch{11,12}
     py312-opensearch{11,12}
     py313-opensearch{11,12}
+    py314-opensearch{11,12}
 
 [testenv]
 deps =


### PR DESCRIPTION
## Summary
- declare Python 3.14 support in packaging
- test Python 3.14 with tox in GitHub and GitLab

## Testing
- `poetry run pytest -q`
- `poetry run pylint openmock`
- `poetry run pre-commit run --files pyproject.toml tox.ini .github/workflows/tox.yml .gitlab-ci.yml CONTRIBUTING.md` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.9')*


------
https://chatgpt.com/codex/tasks/task_e_688e38708e88832797de89ec8c3417e8